### PR TITLE
Add columns to condition navigation

### DIFF
--- a/_sass/modules/condition-navigation.scss
+++ b/_sass/modules/condition-navigation.scss
@@ -1,20 +1,30 @@
 .condition-navigation {
   @extend %contain-floats;
+  @extend .content-measure;
 
   h1 { @extend .heading-xlarge; }
 
   ol {
-    @extend %contain-floats;
-
     font-size: map-get($type-small, small);
+    padding-bottom: 24px;
     border-bottom: 1px solid $border-colour;
 
     @include media(large) {
       font-size: map-get($type-large, small);
+      -webkit-columns: 2;
+      -moz-columns: 2;
+      columns: 2;
     }
   }
 
   li {
-    white-space: nowrap;
+    margin-bottom: 0;
+    padding-bottom: 6px;
+
+    @include media(large) {
+      -webkit-column-break-inside: avoid;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
   }
 }


### PR DESCRIPTION
Small:

<img width="589" alt="screen shot 2015-12-01 at 16 04 59" src="https://cloud.githubusercontent.com/assets/1913757/11506057/5050d72c-9845-11e5-9f92-c986a8ecb19d.png">

Bigger:

<img width="659" alt="screen shot 2015-12-01 at 15 59 32" src="https://cloud.githubusercontent.com/assets/1913757/11505967/d915cfe6-9844-11e5-95d6-0c813d129450.png">

Using css columns in the first instance because it's nice and clean.
See: http://caniuse.com/#search=column and note the IE support.
