### PR TITLE
Fix phase banner on narrow screens

### DIFF
--- a/_sass/modules/phase-banner.scss
+++ b/_sass/modules/phase-banner.scss
@@ -1,9 +1,14 @@
 .phase-banner {
-  max-width: 960px;
-  margin: 0 auto;
+  @extend .block-container;
+
   font-size: map-get($type-small, xsmall);
   line-height: map-get($type-small, leading-xsmall);
-  border-bottom: 1px solid $grey-2;
+
+  p {
+    border-bottom: 1px solid $grey-2;
+    margin: 0;
+    padding: 18px 0;
+  }
 
   .phase-tag {
     display: inline-block;


### PR DESCRIPTION
Make it `@extend .block-container` so it has the same behaviour as the header, body and footer.
##  Before

<img width="1092" alt="screen shot 2015-12-02 at 14 03 45" src="https://cloud.githubusercontent.com/assets/74812/11532703/8f5bc2b6-98fd-11e5-8312-e7ae23c006c8.png">
##  After

<img width="1092" alt="screen shot 2015-12-02 at 14 03 55" src="https://cloud.githubusercontent.com/assets/74812/11532705/925674ca-98fd-11e5-9e8e-04a260b80e1b.png">
