### PR TITLE
Remove stray hyphen from the "understanding medication" section title

### DIFF
--- a/depression-and-anxiety/understanding-medication.md
+++ b/depression-and-anxiety/understanding-medication.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding-medication
+title: Understanding medication
 condition: Depression and anxiety
 nav_order: 4
 ---


### PR DESCRIPTION
For consistency with other section titles.

Loving the new stuff, though! :+1:

Screenshots:

Before:

<img width="633" alt="screenshot 2015-12-04 16 11 33" src="https://cloud.githubusercontent.com/assets/355033/11594444/feaf34f4-9aa1-11e5-9408-8760cbb3118a.png">

After:

<img width="649" alt="screenshot 2015-12-04 16 12 02" src="https://cloud.githubusercontent.com/assets/355033/11594454/081eb5aa-9aa2-11e5-9423-2673782dd0ec.png">
