### PR TITLE
Fix focus

### DIFF
--- a/_sass/global/layout.scss
+++ b/_sass/global/layout.scss
@@ -55,6 +55,10 @@ body {
 
   a {
     color: tint($black, 70%);
+
+    &:focus {
+      color: $black;
+    }
   }
 
   .footer-container {

--- a/_sass/modules/condition-navigation.scss
+++ b/_sass/modules/condition-navigation.scss
@@ -19,12 +19,22 @@
 
   li {
     margin-bottom: 0;
-    padding-bottom: 6px;
+    padding-bottom: 5px;
 
     @include media(large) {
       -webkit-column-break-inside: avoid;
       page-break-inside: avoid;
       break-inside: avoid;
     }
+  }
+
+  a {
+    display: inline-block;
+    padding: 1px 2px;
+  }
+  a:focus {
+    // different focus handling to prevent trailing outline in column layout
+    // background colour is still yellow
+    outline: 0;
   }
 }


### PR DESCRIPTION
Trailing outline when using column layout:

<img width="646" alt="screen shot 2015-12-07 at 10 55 16" src="https://cloud.githubusercontent.com/assets/1913757/11625345/47a68522-9cd2-11e5-8bd6-63937f845cd7.png">

No longer:

<img width="632" alt="screen shot 2015-12-07 at 11 01 41" src="https://cloud.githubusercontent.com/assets/1913757/11625347/4d8b93c4-9cd2-11e5-9c24-f0b0022ade40.png">

Also ensuring $black text on footer link focus:

<img width="434" alt="screen shot 2015-12-07 at 11 01 52" src="https://cloud.githubusercontent.com/assets/1913757/11625357/5a2d8a24-9cd2-11e5-86b6-d25e8dd06100.png">
