### PR TITLE
Add skiplink

### DIFF
--- a/_layouts/condition.html
+++ b/_layouts/condition.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<main id="content" class="block-container">
+<main id="content" class="block-container" role="main">
 
   {% if page.nav_order %}
     <nav class="condition-navigation">

--- a/_layouts/condition.html
+++ b/_layouts/condition.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="block-container">
+<main id="content" class="block-container">
 
   {% if page.nav_order %}
     <nav class="condition-navigation">
@@ -24,11 +24,9 @@ layout: default
     </nav>
   {% endif %}
 
-  <main id="content">
-    <div class="content-measure">
-      {{ content }}
-    </div>
-  </main>
+  <div class="content-measure">
+    {{ content }}
+  </div>
 
   {% if page.nav_order %}
     <nav class="pagination">
@@ -60,4 +58,4 @@ layout: default
     </nav>
   {% endif %}
 
-</div>
+</main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,12 @@
 </head>
 <body>
 
+<div id="skiplink-container">
+  <div>
+    <a href="#content">Skip to main content</a>
+  </div>
+</div>
+
 <div id="global-cookies-banner" role="alert">
   <p>
     NHS.UK uses cookies to make the site simpler.

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<main id="content" class="block-container">
+<main id="content" class="block-container" role="main">
   <div class="content-measure">
     {{ content }}
   </div>

--- a/_sass/global/layout.scss
+++ b/_sass/global/layout.scss
@@ -39,6 +39,11 @@ body {
   }
 }
 
+#content {
+  // prevent margins leaking (helps with skiplink)
+  padding-top: 1px;
+}
+
 #global-footer {
   background-color: $black;
   color: tint($black, 70%);

--- a/_sass/modules/condition-navigation.scss
+++ b/_sass/modules/condition-navigation.scss
@@ -1,4 +1,5 @@
 .condition-navigation {
+
   @extend %contain-floats;
   @extend .content-measure;
 
@@ -37,6 +38,6 @@
   }
 }
 
-.condition-navigation + #content h1 {
+.condition-navigation + .content-measure h1 {
   @extend .heading-xlarge;
 }

--- a/_sass/modules/skiplink.scss
+++ b/_sass/modules/skiplink.scss
@@ -1,0 +1,24 @@
+#skiplink-container {
+  background-color: tint($yellow, 70%);
+
+  & > div {
+    @extend .block-container;
+  }
+
+  a {
+    position: absolute;
+    left: -999em;
+    display: inline-block;
+    padding: 6px;
+    font-size: map-get($type-small, small);
+
+    &:focus {
+      position: static;
+      outline: 0;
+    }
+
+    @include media(large) {
+      font-size: map-get($type-large, small);
+    }
+  }
+}

--- a/public/stylesheets/nhsuk.scss
+++ b/public/stylesheets/nhsuk.scss
@@ -19,6 +19,7 @@
 @import "global/base-typography";
 
 // Modules
+@import "modules/skiplink";
 @import "modules/callouts";
 @import "modules/cookies-banner";
 @import "modules/phase-banner";


### PR DESCRIPTION
<img width="463" alt="screen shot 2015-12-07 at 16 51 02" src="https://cloud.githubusercontent.com/assets/1913757/11633359/bb4ceb4e-9d02-11e5-9550-2ef980abf077.png">

Seems IE still doesn't expose semantic meaning from html5 elements alone - see http://www.html5accessibility.com/ maintained by Paciello Group.

So adding a skiplink and certainly the role for main seems to make sense?
