### PR TITLE
Fix menu moving

### DIFF
--- a/_sass/modules/condition-navigation.scss
+++ b/_sass/modules/condition-navigation.scss
@@ -28,7 +28,7 @@
 
   a {
     display: inline-block;
-    padding: 1px 2px;
+    padding: 0 2px;
   }
   a:focus {
     // different focus handling to prevent trailing outline in column layout


### PR DESCRIPTION
From this:
<img width="659" alt="screen shot 2015-12-08 at 16 02 43" src="https://cloud.githubusercontent.com/assets/1913757/11660485/3c0da2f6-9dc5-11e5-8849-e535fd609d2b.png">
To this:
<img width="640" alt="screen shot 2015-12-08 at 16 02 50" src="https://cloud.githubusercontent.com/assets/1913757/11660490/3fa13478-9dc5-11e5-9c95-41df5a946a79.png">

This PR fixes the awfulness. Why haven't I been fired yet?
