### PR TITLE
Use `s3cmd --acl-public` to make uploads public

### DIFF
--- a/.deliver/config
+++ b/.deliver/config
@@ -3,7 +3,21 @@
 # See https://github.com/gerhard/deliver for details
 
 STRATEGY="s3"
-S3_BUCKET="alpha.nhs.uk"
+
+case "${NHSALPHA_ENVIRONMENT}" in
+    'production' )
+        S3_BUCKET="alpha.nhs.uk"
+        ;;
+    'staging' )
+        S3_BUCKET="alpha-staging.nhs.uk"
+        ;;
+    *)
+        echo
+        echo "Error: Please provide NHSALPHA_ENVIRONMENT=staging|production"
+        exit 2
+        ;;
+esac
+
 S3CMD_OPTIONS="--access_key $AWS_ACCESS_KEY --secret_key $AWS_SECRET_KEY --config .deliver/s3cfg sync --delete-removed"
 
 # Generate the site with jekyll before delivering

--- a/.deliver/config
+++ b/.deliver/config
@@ -18,7 +18,7 @@ case "${NHSALPHA_ENVIRONMENT}" in
         ;;
 esac
 
-S3CMD_OPTIONS="--access_key $AWS_ACCESS_KEY --secret_key $AWS_SECRET_KEY --config .deliver/s3cfg sync --delete-removed"
+S3CMD_OPTIONS="--access_key $AWS_ACCESS_KEY --secret_key $AWS_SECRET_KEY --config .deliver/s3cfg sync --delete-removed --acl-public"
 
 # Generate the site with jekyll before delivering
 ASSETS_DIR="_deploy/"

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Deployment of this app to alpha.nhs.uk requires:
 The access key and secret key are provided as environment variables when
 running the command to deploy:
 
-    AWS_ACCESS_KEY=… AWS_SECRET_KEY=… deliver --verbose
+    AWS_ACCESS_KEY=… AWS_SECRET_KEY=… NHSALPHA_ENVIRONMENT=staging deliver --verbose


### PR DESCRIPTION
@evilstreak I can't reverse engineer your approach to making uploaded files
public for the production bucket - there's no IAM policy and files don't appear
to have special "Everyone" permission.

This approach works but whatever you did might be more appropriate - lemme know.

(Will need rebasing after merging #79)
