### PR TITLE
Generate condition pages for index in ruby

### DIFF
--- a/_plugins/index_content_pages.rb
+++ b/_plugins/index_content_pages.rb
@@ -1,0 +1,13 @@
+module IndexContentPages
+  class Generator < Jekyll::Generator
+    def generate(site)
+      condition_pages = site.pages
+        .select { |page| page.data.fetch('condition', false) }
+        .select { |page| page.data.fetch('nav_order', 1) == 1 }
+        .sort_by { |page| page.data['condition'] }
+
+      index_page = site.pages.find { |page| page.name == 'index.html' }
+      index_page.data['condition_pages'] = condition_pages
+    end
+  end
+end

--- a/index.html
+++ b/index.html
@@ -13,11 +13,8 @@
     <h2>Conditions</h2>
 
     <ul>
-      {% assign condition_pages = site.pages | sort: "condition" %}
-      {% for p in condition_pages %}
-        {% if p.condition %}{% unless p.nav_order > 1 %}
+      {% for p in page.condition_pages %}
           <li><a href="{{ p.url }}">{{ p.condition }}</a></li>
-        {% endunless %}{% endif %}
       {% endfor %}
     </ul>
 


### PR DESCRIPTION
Make a plugin which finds condition pages (or the first of a set of condition
pages) and adds them as data to the index page.

Previously we were doing this in liquid which was making whitespace 
non-deterministically. It's too much logic to do in the template language.
