### PR TITLE
Redo @extend for items that need 34em width

### DIFF
--- a/_sass/global/layout.scss
+++ b/_sass/global/layout.scss
@@ -91,3 +91,9 @@ body {
     }
   }
 }
+
+// use for items that need to ape the content measure at class level
+// i.e. pagination block, condition-navigation
+.measure {
+  max-width: 34em;
+}

--- a/_sass/modules/condition-navigation.scss
+++ b/_sass/modules/condition-navigation.scss
@@ -1,7 +1,7 @@
 .condition-navigation {
 
   @extend %contain-floats;
-  @extend .content-measure;
+  @extend .measure;
 
   ol {
     font-size: map-get($type-small, small);

--- a/_sass/modules/pagination.scss
+++ b/_sass/modules/pagination.scss
@@ -1,6 +1,6 @@
 .pagination {
   @extend %contain-floats;
-  @extend .content-measure;
+  @extend .measure;
 
   margin: 48px 0;
   padding-top: 18px;


### PR DESCRIPTION
`.content-measure` works on child items now, because fb357837a1b7c6daae3d80459dcbfd1c28337b36

`.measure` is a simple 34em max-width class to be used by items that need
to ape that width. For example `.pagination` and `.condition-navigation`
