### PR TITLE
Remove link to diabetes.co.uk

### DIFF
--- a/type-2-diabetes/food-and-keeping-active.md
+++ b/type-2-diabetes/food-and-keeping-active.md
@@ -24,7 +24,6 @@ The charity Diabetes UK has lots of  information on:
 - [food for people with diabetes](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Food-and-diabetes/What-is-a-healthy-balanced-diet/)
 - [tips on eating with your family and eating out](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/)
 - [recipes for people with diabetes](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Cooking-for-people-with-diabetes/)
-- [food and nutrition message board](http://www.diabetes.co.uk/forum/category/food-nutrition-and-recipes.3/).
 
 <div class="notice" role="note" aria-label="Information">
   <p>


### PR DESCRIPTION
As Said rightly points out here: 
http://forum.digital.nhs.uk/t/feedback-on-type-2-diabetes-condition-pages/44/4

We are incorrectly attributing a `diabates.co.uk` page to Diabetes UK
(`diabetes.org.uk`).

For now I'm removing this error by deleting the link.

Separately, we should decide how or whether to reinstate this link (correctly 
attributed). As Said points out they are a commercial organisation with their
own agenda, and we need a position on how/whether we link to them.
